### PR TITLE
Fix for ms win

### DIFF
--- a/assets-life.go
+++ b/assets-life.go
@@ -102,6 +102,7 @@ import (
 // Root is the root of the file system.
 var Root http.FileSystem = fileSystem{
 `
+	rel = filepath.ToSlash(rel)
 	fmt.Fprintf(f, header, filename, "go:generate go run "+filename+" \""+rel+"\" . "+name, name)
 
 	type file struct {
@@ -378,6 +379,7 @@ func build(in, out, name string) error {
 		return err
 	}
 	header := %c%s%c
+	rel = filepath.ToSlash(rel)
 	fmt.Fprintf(f, header, filename, "go:generate go run "+filename+" \""+rel+"\" . "+name, name)
 
 	type file struct {

--- a/assets-life.go
+++ b/assets-life.go
@@ -397,6 +397,10 @@ func build(in, out, name string) error {
 
 	var i int
 	err = filepath.Walk(in, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
 		// ignore hidden files
 		if strings.HasPrefix(info.Name(), ".") {
 			return nil

--- a/assets-life.go
+++ b/assets-life.go
@@ -116,6 +116,10 @@ var Root http.FileSystem = fileSystem{
 
 	var i int
 	err = filepath.Walk(in, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
 		// ignore hidden files
 		if strings.HasPrefix(info.Name(), ".") {
 			return nil


### PR DESCRIPTION
Fixed an issue where `go generate` command doesn't work on windows.

The go generate command does not work for the following reason.

* The path separator of `go generate` directive generated by `assets-life` command is not Unix style

Therefore, the `go generate` command can be executed in the windows by the following way.

* Add `filepath.ToSlash()` before generating `go generate` directive

And, when the `go generate` command fails, `filepath.Walk()` is not checked for errors and the cause of the error is not reported.
Therefore, error handling has been added too.

Thanks.