### PR TITLE
allow Root.Open without leading slash

### DIFF
--- a/assets-life.go
+++ b/assets-life.go
@@ -94,6 +94,7 @@ import (
 	"net/http"
 	"os"
 	"path"
+	"path/filepath"
 	"sort"
 	"strings"
 	"time"
@@ -191,6 +192,7 @@ var Root http.FileSystem = fileSystem{
 type fileSystem []file
 
 func (fs fileSystem) Open(name string) (http.File, error) {
+	name = filepath.FromSlash(path.Clean("/" + name))
 	i := sort.Search(len(fs), func(i int) bool { return fs[i].name >= name })
 	if i >= len(fs) || fs[i].name != name {
 		return nil, &os.PathError{


### PR DESCRIPTION
Add leading slash to allow open files in the root directory.